### PR TITLE
Resolving "bad interpreter" error

### DIFF
--- a/src/sarch.py
+++ b/src/sarch.py
@@ -1,4 +1,4 @@
-#! /bin/python3.8
+#! /usr/bin/python3
 import sys
 
 

--- a/src/sbase64.py
+++ b/src/sbase64.py
@@ -1,4 +1,4 @@
-#! /bin/python3.8
+#! /usr/bin/python3
 import sys
 import base64
 import binascii

--- a/src/sbasename.py
+++ b/src/sbasename.py
@@ -1,4 +1,4 @@
-#!/bin/python3.8
+#! /usr/bin/python3
 import os
 import sys
 import re

--- a/src/scat.py
+++ b/src/scat.py
@@ -1,4 +1,4 @@
-#! /bin/python3.8
+#! /usr/bin/python3
 import sys
 
 

--- a/src/scp.py
+++ b/src/scp.py
@@ -1,4 +1,4 @@
-#!/bin/python3.8
+#! /usr/bin/python3
 import sys
 
 

--- a/src/sdd.py
+++ b/src/sdd.py
@@ -1,4 +1,4 @@
-#!/bin/python3.8
+#! /usr/bin/python3
 import sys
 
 

--- a/src/sgrep.py
+++ b/src/sgrep.py
@@ -1,4 +1,4 @@
-#! /bin/python3.8
+#! /usr/bin/python3
 import sys
 import re
 

--- a/src/sls.py
+++ b/src/sls.py
@@ -1,4 +1,4 @@
-#!/bin/python3.8
+#! /usr/bin/python3
 import sys
 import os
 

--- a/src/smkdir.py
+++ b/src/smkdir.py
@@ -1,4 +1,4 @@
-#!/bin/python3.8
+#! /usr/bin/python3
 import os
 import sys
 

--- a/src/srmdir.py
+++ b/src/srmdir.py
@@ -1,4 +1,4 @@
-#!/bin/python3.8
+#! /usr/bin/python3
 import os
 import sys
 

--- a/src/swhoami.py
+++ b/src/swhoami.py
@@ -1,4 +1,4 @@
-#! /bin/python3.8
+#! /usr/bin/python3
 import getpass
 import sys
 

--- a/src/syes.py
+++ b/src/syes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#! /usr/bin/python3
 import sys
 
 def main():


### PR DESCRIPTION
Changing interpreter path from `/bin/python3.8` to `/usr/bin/python3`.